### PR TITLE
Making repository base generic

### DIFF
--- a/src/Services/Ordering/Ordering.Application/Contracts/Persistence/IRepositoryBase.cs
+++ b/src/Services/Ordering/Ordering.Application/Contracts/Persistence/IRepositoryBase.cs
@@ -3,27 +3,27 @@ using System.Linq.Expressions;
 
 namespace Ordering.Application.Contracts.Persistence
 {
-    public interface IRepositoryBase<T> where T : EntityBase
+    public interface IRepositoryBase<TEntity> where TEntity : EntityBase
     {
-        Task<IReadOnlyList<T>> GetAllAsync();
+        Task<IReadOnlyList<TEntity>> GetAllAsync();
 
-        Task<IReadOnlyList<T>> GetAsync(Expression<Func<T, bool>> predicate);
+        Task<IReadOnlyList<TEntity>> GetAsync(Expression<Func<TEntity, bool>> predicate);
 
-        Task<IReadOnlyList<T>> GetAsync(Expression<Func<T, bool>> predicate = null,
-                                        Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+        Task<IReadOnlyList<TEntity>> GetAsync(Expression<Func<TEntity, bool>> predicate = null,
+                                        Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> orderBy = null,
                                         string includeString = null,
                                         bool disableTracking = true);
 
-        Task<IReadOnlyList<T>> GetAsync(Expression<Func<T, bool>> predicate = null,
-                                       Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
-                                       List<Expression<Func<T, object>>> includes = null,
+        Task<IReadOnlyList<TEntity>> GetAsync(Expression<Func<TEntity, bool>> predicate = null,
+                                       Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> orderBy = null,
+                                       List<Expression<Func<TEntity, object>>> includes = null,
                                        bool disableTracking = true);
-        Task<T?> GetByIdAsync(int id);
+        Task<TEntity?> GetByIdAsync(int id);
 
-        Task<T> AddAsync(T entity);
+        Task<TEntity> AddAsync(TEntity entity);
 
-        Task UpdateAsync(T entity);
+        Task UpdateAsync(TEntity entity);
 
-        Task DeleteAsync(T entity);
+        Task DeleteAsync(TEntity entity);
     }
 }

--- a/src/Services/Ordering/Ordering.Infrastructure/InfrastructureServiceRegistration.cs
+++ b/src/Services/Ordering/Ordering.Infrastructure/InfrastructureServiceRegistration.cs
@@ -17,7 +17,6 @@ namespace Ordering.Infrastructure
             services.AddDbContext<OrderContext>(options =>
                 options.UseSqlServer(configuration.GetConnectionString("OrderingConnectionString")));
 
-            services.AddScoped(typeof(IRepositoryBase<>), typeof(RepositoryBase<>));
             services.AddScoped<IOrderRepository, OrderRepository>();
 
             services.Configure<EmailSettings>(c => configuration.GetSection("EmailSettings"));

--- a/src/Services/Ordering/Ordering.Infrastructure/Repositories/OrderRepository.cs
+++ b/src/Services/Ordering/Ordering.Infrastructure/Repositories/OrderRepository.cs
@@ -5,7 +5,7 @@ using Ordering.Infrastructure.Persistence;
 
 namespace Ordering.Infrastructure.Repositories
 {
-    public class OrderRepository : RepositoryBase<Order>, IOrderRepository
+    public class OrderRepository : RepositoryBase<Order, OrderContext>, IOrderRepository
     {
         public OrderRepository(OrderContext dbContext) : base(dbContext)
         {

--- a/src/Services/Ordering/Ordering.Infrastructure/Repositories/RepositoryBase.cs
+++ b/src/Services/Ordering/Ordering.Infrastructure/Repositories/RepositoryBase.cs
@@ -1,33 +1,32 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Ordering.Application.Contracts.Persistence;
 using Ordering.Domain.Common;
-using Ordering.Infrastructure.Persistence;
 using System.Linq.Expressions;
 
 namespace Ordering.Infrastructure.Repositories
 {
-    public class RepositoryBase<T> : IRepositoryBase<T> where T : EntityBase
+    public class RepositoryBase<TEntity, TContext> : IRepositoryBase<TEntity> where TEntity : EntityBase where TContext : DbContext
     {
-        protected readonly OrderContext _dbContext;
+        protected readonly TContext _dbContext;
 
-        public RepositoryBase(OrderContext dbContext)
+        public RepositoryBase(TContext dbContext)
         {
             _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         }
 
-        public async Task<IReadOnlyList<T>> GetAllAsync()
+        public async Task<IReadOnlyList<TEntity>> GetAllAsync()
         {
-            return await _dbContext.Set<T>().ToListAsync();
+            return await _dbContext.Set<TEntity>().ToListAsync();
         }
 
-        public async Task<IReadOnlyList<T>> GetAsync(Expression<Func<T, bool>> predicate)
+        public async Task<IReadOnlyList<TEntity>> GetAsync(Expression<Func<TEntity, bool>> predicate)
         {
-            return await _dbContext.Set<T>().Where(predicate).ToListAsync();
+            return await _dbContext.Set<TEntity>().Where(predicate).ToListAsync();
         }
 
-        public async Task<IReadOnlyList<T>> GetAsync(Expression<Func<T, bool>> predicate = null, Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null, string includeString = null, bool disableTracking = true)
+        public async Task<IReadOnlyList<TEntity>> GetAsync(Expression<Func<TEntity, bool>> predicate = null, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> orderBy = null, string includeString = null, bool disableTracking = true)
         {
-            IQueryable<T> query = _dbContext.Set<T>();
+            IQueryable<TEntity> query = _dbContext.Set<TEntity>();
             if (disableTracking)
                 query = query.AsNoTracking();
 
@@ -42,9 +41,9 @@ namespace Ordering.Infrastructure.Repositories
             return await query.ToListAsync();
         }
 
-        public async Task<IReadOnlyList<T>> GetAsync(Expression<Func<T, bool>> predicate = null, Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null, List<Expression<Func<T, object>>> includes = null, bool disableTracking = true)
+        public async Task<IReadOnlyList<TEntity>> GetAsync(Expression<Func<TEntity, bool>> predicate = null, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> orderBy = null, List<Expression<Func<TEntity, object>>> includes = null, bool disableTracking = true)
         {
-            IQueryable<T> query = _dbContext.Set<T>();
+            IQueryable<TEntity> query = _dbContext.Set<TEntity>();
             if (disableTracking)
                 query = query.AsNoTracking();
 
@@ -60,27 +59,27 @@ namespace Ordering.Infrastructure.Repositories
             return await query.ToListAsync();
         }
 
-        public virtual async Task<T?> GetByIdAsync(int id)
+        public virtual async Task<TEntity?> GetByIdAsync(int id)
         {
-            return await _dbContext.Set<T>().FindAsync(id);
+            return await _dbContext.Set<TEntity>().FindAsync(id);
         }
 
-        public async Task<T> AddAsync(T entity)
+        public async Task<TEntity> AddAsync(TEntity entity)
         {
-            _dbContext.Set<T>().Add(entity);
+            _dbContext.Set<TEntity>().Add(entity);
             await _dbContext.SaveChangesAsync();
             return entity;
         }
 
-        public async Task UpdateAsync(T entity)
+        public async Task UpdateAsync(TEntity entity)
         {
             _dbContext.Entry(entity).State = EntityState.Modified;
             await _dbContext.SaveChangesAsync();
         }
 
-        public async Task DeleteAsync(T entity)
+        public async Task DeleteAsync(TEntity entity)
         {
-            _dbContext.Set<T>().Remove(entity);
+            _dbContext.Set<TEntity>().Remove(entity);
             await _dbContext.SaveChangesAsync();
         }
     }


### PR DESCRIPTION
Currently in Repository base we have reference to OrderContext. Changing to generic Context will fit better to the purpose of the class.